### PR TITLE
Tests

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -70,11 +70,12 @@ func StringsEqual(a []string, b []string) bool {
 	if len(a) != len(b) {
 		return false
 	}
-	for _, namespace := range a {
+	for _, needle := range a {
 		found := false
-		for _, expected := range b {
-			if expected == namespace {
+		for i, expected := range b {
+			if expected == needle {
 				found = true
+				b = append(b[:i], b[i+1:]...)
 				break
 			}
 		}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -70,12 +70,14 @@ func StringsEqual(a []string, b []string) bool {
 	if len(a) != len(b) {
 		return false
 	}
+
+	checkedIndexes := map[int]bool{}
 	for _, needle := range a {
 		found := false
 		for i, expected := range b {
-			if expected == needle {
+			if expected == needle && !checkedIndexes[i] {
 				found = true
-				b = append(b[:i], b[i+1:]...)
+				checkedIndexes[i] = true
 				break
 			}
 		}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -27,7 +27,7 @@ func TestRun(t *testing.T) {
 		},
 		{
 			name:    "Successful command",
-			command: "bash",
+			command: "echo",
 			args:    []string{"hello"},
 		},
 	}
@@ -63,7 +63,7 @@ func TestOutput(t *testing.T) {
 			name:           "Successful command",
 			command:        "echo",
 			args:           []string{"hello"},
-			expectedOutput: "hello",
+			expectedOutput: "hello\n",
 		},
 	}
 

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -16,18 +16,18 @@ type runTestCase struct {
 	command string
 	args    []string
 
-	expectedErr string
+	expectedErr bool
 }
 
 func TestRun(t *testing.T) {
 	testCases := []runTestCase{
 		{
 			name:        "Error in command",
-			expectedErr: "Error in command: exec: \"\": executable file not found in %PATH% => ",
+			expectedErr: true,
 		},
 		{
 			name:    "Successful command",
-			command: "echo",
+			command: "bash",
 			args:    []string{"hello"},
 		},
 	}
@@ -35,10 +35,10 @@ func TestRun(t *testing.T) {
 	for _, testCase := range testCases {
 		err := Run(testCase.command, testCase.args...)
 
-		if testCase.expectedErr == "" {
+		if testCase.expectedErr == false {
 			assert.NilError(t, err, "Unexpected error in testCase %s", testCase.name)
-		} else {
-			assert.Error(t, err, testCase.expectedErr, "No or wrong error in testCase %s", testCase.name)
+		} else if err == nil {
+			t.Fatalf("No error in testCase %s", testCase.name)
 		}
 	}
 }
@@ -49,7 +49,7 @@ type outputTestCase struct {
 	command string
 	args    []string
 
-	expectedErr    string
+	expectedErr    bool
 	expectedOutput string
 }
 
@@ -57,7 +57,7 @@ func TestOutput(t *testing.T) {
 	testCases := []outputTestCase{
 		{
 			name:        "Error in command",
-			expectedErr: "Error in command: exec: \"\": executable file not found in %PATH% => ",
+			expectedErr: true,
 		},
 		{
 			name:           "Successful command",
@@ -70,10 +70,10 @@ func TestOutput(t *testing.T) {
 	for _, testCase := range testCases {
 		output, err := Output(testCase.command, testCase.args...)
 
-		if testCase.expectedErr == "" {
+		if testCase.expectedErr == false {
 			assert.NilError(t, err, "Unexpected error in testCase %s", testCase.name)
-		} else {
-			assert.Error(t, err, testCase.expectedErr, "No or wrong error in testCase %s", testCase.name)
+		} else if err == nil {
+			t.Fatalf("No error in testCase %s", testCase.name)
 		}
 
 		assert.Equal(t, output, testCase.expectedOutput, "Unexpected output in testCase %s", testCase.name)

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,3 +1,187 @@
 package util
 
-// TODO
+import (
+	"testing"
+
+	"github.com/kiosk-sh/kiosk/pkg/apis/tenancy"
+
+	"gotest.tools/assert"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type runTestCase struct {
+	name string
+
+	command string
+	args    []string
+
+	expectedErr string
+}
+
+func TestRun(t *testing.T) {
+	testCases := []runTestCase{
+		{
+			name:        "Error in command",
+			expectedErr: "Error in command: exec: \"\": executable file not found in %PATH% => ",
+		},
+		{
+			name:    "Successful command",
+			command: "echo",
+			args:    []string{"hello"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		err := Run(testCase.command, testCase.args...)
+
+		if testCase.expectedErr == "" {
+			assert.NilError(t, err, "Unexpected error in testCase %s", testCase.name)
+		} else {
+			assert.Error(t, err, testCase.expectedErr, "No or wrong error in testCase %s", testCase.name)
+		}
+	}
+}
+
+type outputTestCase struct {
+	name string
+
+	command string
+	args    []string
+
+	expectedErr    string
+	expectedOutput string
+}
+
+func TestOutput(t *testing.T) {
+	testCases := []outputTestCase{
+		{
+			name:        "Error in command",
+			expectedErr: "Error in command: exec: \"\": executable file not found in %PATH% => ",
+		},
+		{
+			name:           "Successful command",
+			command:        "echo",
+			args:           []string{"hello"},
+			expectedOutput: "hello",
+		},
+	}
+
+	for _, testCase := range testCases {
+		output, err := Output(testCase.command, testCase.args...)
+
+		if testCase.expectedErr == "" {
+			assert.NilError(t, err, "Unexpected error in testCase %s", testCase.name)
+		} else {
+			assert.Error(t, err, testCase.expectedErr, "No or wrong error in testCase %s", testCase.name)
+		}
+
+		assert.Equal(t, output, testCase.expectedOutput, "Unexpected output in testCase %s", testCase.name)
+	}
+}
+
+type getAccountFromNamespaceTestCase struct {
+	name string
+
+	annotations map[string]string
+
+	expectedAccount string
+}
+
+func TestGetAccountFromNamespace(t *testing.T) {
+	testCases := []getAccountFromNamespaceTestCase{
+		{
+			name: "No annotations",
+		},
+		{
+			name: "Get account",
+			annotations: map[string]string{
+				tenancy.SpaceAnnotationAccount: "myAccount",
+			},
+			expectedAccount: "myAccount",
+		},
+	}
+
+	for _, testCase := range testCases {
+		account := GetAccountFromNamespace(&corev1.Namespace{
+			ObjectMeta: v1.ObjectMeta{
+				Annotations: testCase.annotations,
+			},
+		})
+		assert.Equal(t, account, testCase.expectedAccount, "Unexpected account in testCase %s", testCase.name)
+	}
+}
+
+type isNamespaceInitializingTestCase struct {
+	name string
+
+	annotations map[string]string
+
+	expected bool
+}
+
+func TestIsNamespaceInitializing(t *testing.T) {
+	testCases := []isNamespaceInitializingTestCase{
+		{
+			name: "No annotations",
+		},
+		{
+			name: "It is initializing",
+			annotations: map[string]string{
+				tenancy.SpaceAnnotationInitializing: "true",
+			},
+			expected: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		result := IsNamespaceInitializing(&corev1.Namespace{
+			ObjectMeta: v1.ObjectMeta{
+				Annotations: testCase.annotations,
+			},
+		})
+		assert.Equal(t, result, testCase.expected, "Unexpected result in testCase %s", testCase.name)
+	}
+}
+
+type stringsEqualTestCase struct {
+	name string
+
+	arr1 []string
+	arr2 []string
+
+	expected bool
+}
+
+func TestStringsEqual(t *testing.T) {
+	testCases := []stringsEqualTestCase{
+		{
+			name:     "Unequal length",
+			arr1:     []string{""},
+			expected: false,
+		},
+		{
+			name:     "Unequal content",
+			arr1:     []string{"inBoth", "arr1Exclusive"},
+			arr2:     []string{"arr2Exclusive", "inBoth"},
+			expected: false,
+		},
+		{
+			name:     "Unequal number of insances",
+			arr1:     []string{"OnceInArr1", "TwiceInArr1", "TwiceInArr1"},
+			arr2:     []string{"OnceInArr1", "OnceInArr1", "TwiceInArr1"},
+			expected: false,
+		},
+		{
+			name:     "Equal but wrong order",
+			arr1:     []string{"a", "a", "b", "c"},
+			arr2:     []string{"c", "a", "b", "a"},
+			expected: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		result := StringsEqual(testCase.arr1, testCase.arr2)
+		assert.Equal(t, result, testCase.expected, "Unexpected result in testCase %s", testCase.name)
+	}
+}


### PR DESCRIPTION
- Add test for pkg/util/util.go
- Fix found issue: StringsEqual said yes when the two string arrays have different numbers of same strings. For example: Arr1: "a","a","b" Arr2: "a","b","b"