### PR TITLE
Delete template instance resource on instance delete

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= controller:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersiasdsaddsaasddasdsons=true"
+CRD_OPTIONS ?= "crd:trivialVersions=true"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/pkg/apis/config/v1alpha1/templateinstance_types.go
+++ b/pkg/apis/config/v1alpha1/templateinstance_types.go
@@ -20,6 +20,10 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+// TemplateInstanceNoOwnerAnnotation if this annotation is set on a template instance,
+// the template instance is not setting itself as the owner of the created objects
+const TemplateInstanceNoOwnerAnnotation = "templateinstance.config.kiosk.sh/no-owner"
+
 // TemplateInstanceSpec holds the expected cluster status of the template instance
 type TemplateInstanceSpec struct {
 	// The template to instantiate. This is an immutable field

--- a/pkg/manager/controllers/templateinstance_controller.go
+++ b/pkg/manager/controllers/templateinstance_controller.go
@@ -131,6 +131,14 @@ func (r *TemplateInstanceReconciler) deployObjects(ctx context.Context, template
 	for _, object := range objects {
 		object.SetNamespace(templateInstance.Namespace)
 
+		// Set owner controller
+		if shouldSetOwner(templateInstance) {
+			err := ctrl.SetControllerReference(templateInstance, object, r.Scheme)
+			if err != nil {
+				return err
+			}
+		}
+
 		// Get group version
 		gv, err := schema.ParseGroupVersion(object.GetAPIVersion())
 		if err != nil {
@@ -160,6 +168,10 @@ func (r *TemplateInstanceReconciler) deployObjects(ctx context.Context, template
 	}
 
 	return nil
+}
+
+func shouldSetOwner(templateInstance *configv1alpha1.TemplateInstance) bool {
+	return templateInstance.Annotations == nil || templateInstance.Annotations[configv1alpha1.TemplateInstanceNoOwnerAnnotation] != "true"
 }
 
 func (r *TemplateInstanceReconciler) setFailed(ctx context.Context, templateInstance *configv1alpha1.TemplateInstance, reason, message string) error {


### PR DESCRIPTION
This pull requests adds that resources created by a template instance will be deleted, if the owning template instance is deleted