### PR TITLE
Allow annotations and labels on space creation

### DIFF
--- a/pkg/apis/tenancy/validation/space.go
+++ b/pkg/apis/tenancy/validation/space.go
@@ -28,13 +28,6 @@ func ValidateName(name string, prefix bool) []string {
 // ValidateSpace tests required fields for a Space.
 func ValidateSpace(space *tenancy.Space) field.ErrorList {
 	allErrs := validation.ValidateObjectMeta(&space.ObjectMeta, false, ValidateName, field.NewPath("metadata"))
-	if len(space.Annotations) > 0 {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "annotations"), space.Annotations, "field is immutable, try updating the namespace"))
-	}
-	if len(space.Labels) > 0 {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "labels"), space.Labels, "field is immutable, try updating the namespace"))
-	}
-
 	return allErrs
 }
 

--- a/pkg/apiserver/registry/space/storage.go
+++ b/pkg/apiserver/registry/space/storage.go
@@ -208,7 +208,7 @@ func (r *spaceStorage) Create(ctx context.Context, obj runtime.Object, createVal
 
 	// Check if user can access account and create space
 	var account *configv1alpha1.Account
-	if canCreate == false {
+	if canCreate == false || space.Spec.Account != "" {
 		accounts, err := r.authCache.GetAccountsForUser(user, "get")
 		if err != nil {
 			return nil, err
@@ -256,8 +256,12 @@ func (r *spaceStorage) Create(ctx context.Context, obj runtime.Object, createVal
 			}
 
 			// Apply namespace annotations & labels
-			space.ObjectMeta.Labels = account.Spec.Space.SpaceTemplate.Labels
-			space.ObjectMeta.Annotations = account.Spec.Space.SpaceTemplate.Annotations
+			if account.Spec.Space.SpaceTemplate.Labels != nil {
+				space.ObjectMeta.Labels = account.Spec.Space.SpaceTemplate.Labels
+			}
+			if account.Spec.Space.SpaceTemplate.Annotations != nil {
+				space.ObjectMeta.Annotations = account.Spec.Space.SpaceTemplate.Annotations
+			}
 
 			canCreate = true
 		}


### PR DESCRIPTION
## Changes
- Allow annotations and labels on space creation by default. To prevent user defined annotations and labels on space creation you can set the `account.spec.space.spaceTemplate.annotations / labels` which will overwrite the user defined ones (#40)