### PR TITLE
upgrade helm & fix permission error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM golang:1.13 as builder
 WORKDIR /workspace
 
 # Install Helm 3
-RUN bash -c "curl -s https://get.helm.sh/helm-v3.1.1-linux-amd64.tar.gz > helm3.tar.gz" && tar -zxvf helm3.tar.gz linux-amd64/helm && chmod +x linux-amd64/helm && mv linux-amd64/helm /workspace/helm && rm helm3.tar.gz && rm -R linux-amd64
+RUN bash -c "curl -s https://get.helm.sh/helm-v3.1.2-linux-amd64.tar.gz > helm3.tar.gz" && tar -zxvf helm3.tar.gz linux-amd64/helm && chmod +x linux-amd64/helm && mv linux-amd64/helm /workspace/helm && rm helm3.tar.gz && rm -R linux-amd64
 
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -24,10 +24,9 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -mod vendor -o
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static
 WORKDIR /
 COPY --from=builder /workspace/kiosk .
 COPY --from=builder /workspace/helm .
-USER nonroot:nonroot
 
-# No entrypoint we do this in the kube yamls
+ENTRYPOINT ["/kiosk"]


### PR DESCRIPTION
## Changes
- kiosk doesn't require cert-manager anymore and instead manages its certificates on its own
- kiosk automatically creates and updates the validatingwebhookconfiguration & apiservice
- upgraded helm to v3.1.2