### PR TITLE
Sync subjects for all account cluster role bindings

### DIFF
--- a/pkg/manager/controllers/account_controller.go
+++ b/pkg/manager/controllers/account_controller.go
@@ -145,7 +145,7 @@ func (r *AccountReconciler) syncClusterRoles(ctx context.Context, account *confi
 		// Create new cluster role
 		clusterRole := &rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "kiosk-account-" + account.Name + "-",
+				GenerateName: RBACGenerateName(account),
 			},
 			Rules: newRules,
 		}
@@ -192,7 +192,7 @@ func (r *AccountReconciler) syncClusterRoles(ctx context.Context, account *confi
 	if !found {
 		clusterRoleBinding := &rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "kiosk-account-" + account.Name + "-",
+				GenerateName: RBACGenerateName(account),
 			},
 			RoleRef: rbacv1.RoleRef{
 				APIGroup: rbacv1.GroupName,
@@ -292,4 +292,13 @@ func (r *AccountReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&rbacv1.RoleBinding{}).
 		For(&configv1alpha1.Account{}).
 		Complete(r)
+}
+
+func RBACGenerateName(account *configv1alpha1.Account) string {
+	name := account.Name
+	if len(name) > 42 {
+		name = name[:42]
+	}
+
+	return "kiosk-account-" + name + "-"
 }

--- a/pkg/manager/helm/template.go
+++ b/pkg/manager/helm/template.go
@@ -101,6 +101,7 @@ func (h *helm) Template(client client.Client, name, namespace string, config *co
 		args = append(args, "--values", p)
 	}
 
+	args = append(args, "--include-crds")
 	out, err := h.runner(args)
 	if err != nil {
 		return nil, err

--- a/pkg/manager/helm/template_test.go
+++ b/pkg/manager/helm/template_test.go
@@ -157,7 +157,7 @@ func TestTemplate(t *testing.T) {
 			retArgs = args
 
 			if test.expectedArgs != "" {
-				valuesFileName := args[len(args)-1]
+				valuesFileName := args[len(args)-2]
 				bs, err := ioutil.ReadFile(valuesFileName)
 				if err != nil {
 					t.Fatalf("Test %s: could not read values file: %s", testName, err)


### PR DESCRIPTION
## Changes
- kiosk now syncs all account owned cluster role bindings subjects
- deploys crds in helm charts aswell
- reget namespace and retry namespace update on conflict (#62)