### PR TITLE
improvement: add UPDATE_WEBHOOK and UPDATE_APISERVICE variables

### DIFF
--- a/chart/templates/apiserviceservice.yaml
+++ b/chart/templates/apiserviceservice.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.apiservice }}
+{{- if .Values.apiservice.create }}
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
@@ -29,3 +31,5 @@ spec:
   selector:
     app: {{ template "kiosk.fullname" . }}
     release: {{ .Release.Name }}
+{{- end }}
+{{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -37,6 +37,23 @@ spec:
         image: "kiosksh/kiosk:{{ .Chart.Version }}"
         {{- end }}
         name: kiosk
+        env:
+          {{- if .Values.webhook }}
+          {{- if not .Values.webhook.create }}
+          - name: UPDATE_WEBHOOK
+            value: "false"
+          {{- end }}
+          {{- end }}
+          {{- if .Values.apiservice }}
+          {{- if not .Values.apiservice.create }}
+          - name: UPDATE_APISERVICE
+            value: "false"
+          {{- end }}
+          {{- end }}
+          {{- range $key, $value := .Values.env }}
+          - name: {{ $key | quote }}
+            value: {{ $value | quote }}
+          {{- end }}
         {{- if .Values.livenessProbe.enabled }}
         livenessProbe:
           httpGet:

--- a/chart/templates/webhook.yaml
+++ b/chart/templates/webhook.yaml
@@ -1,4 +1,8 @@
+{{- if .Values.webhook }}
+{{- if .Values.webhook.create }}
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: kiosk
+{{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -4,6 +4,8 @@
 
 replicaCount: 1
 
+env: {}
+
 readinessProbe:
   enabled: true
 
@@ -21,6 +23,12 @@ kiosk:
     requests:
       memory: 128Mi
       cpu: 50m
+
+webhook:
+  create: true
+
+apiservice:
+  create: true
 
 serviceAccount:
   name: serviceaccount

--- a/cmd/kiosk/main.go
+++ b/cmd/kiosk/main.go
@@ -109,6 +109,7 @@ func main() {
 		NewClient:          blockingcacheclient.NewCacheClient,
 		Scheme:             scheme,
 		MetricsBindAddress: ":8080",
+		CertDir:            certhelper.WebhookCertFolder,
 		LeaderElection:     false,
 		Port:               9443,
 	})
@@ -194,17 +195,21 @@ func main() {
 	}()
 
 	// setup validatingwebhookconfiguration
-	err = validatingwebhookconfiguration.EnsureValidatingWebhookConfiguration(context.Background(), mgr.GetClient())
-	if err != nil {
-		setupLog.Error(err, "unable to set up validating webhook configuration")
-		os.Exit(1)
+	if os.Getenv("UPDATE_WEBHOOK") != "false" {
+		err = validatingwebhookconfiguration.EnsureValidatingWebhookConfiguration(context.Background(), mgr.GetClient())
+		if err != nil {
+			setupLog.Error(err, "unable to set up validating webhook configuration")
+			os.Exit(1)
+		}
 	}
 
 	// setup apiservice
-	err = apiservice.EnsureAPIService(context.Background(), mgr.GetClient())
-	if err != nil {
-		setupLog.Error(err, "unable to set up apiservice")
-		os.Exit(1)
+	if os.Getenv("UPDATE_APISERVICE") != "false" {
+		err = apiservice.EnsureAPIService(context.Background(), mgr.GetClient())
+		if err != nil {
+			setupLog.Error(err, "unable to set up apiservice")
+			os.Exit(1)
+		}
 	}
 
 	// Wait till stopChan is closed


### PR DESCRIPTION
### Changes
- Adds the environment variables UPDATE_WEBHOOK and UPDATE_APISERVICE to disable the dynamic provisioning of them (#78)
- Adds a new option `env` in the chart to specify environment variables
- Adds a new option `webhook.create` in the chart to skip webhook creation
- Adds a new option `apiservice.create` in the chart to skip apiservice creation